### PR TITLE
Endpoint/delete card

### DIFF
--- a/server/src/controllers/cardControllers/deleteCard.mjs
+++ b/server/src/controllers/cardControllers/deleteCard.mjs
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const deleteCard = async (req, res) => {
+	const { query } = req;
+	const { id } = query;
+
+	await prisma.user
+		.delete({
+			where: { id: parseInt(id) },
+		})
+		.then(() => {
+			res.status(200).json({ msg: "Your Card has been successfully deleted" });
+		})
+		.catch((err) => {
+			res.status(400).json({ msg: err.message });
+		});
+};
+
+export default deleteCard;

--- a/server/src/controllers/cardControllers/getCard.mjs
+++ b/server/src/controllers/cardControllers/getCard.mjs
@@ -1,4 +1,4 @@
-import { len, data } from "../services/Card/index.mjs";
+import { len, data } from "../../services/Card/index.mjs";
 
 const cardControllers = async (req, res) => {
 	const { query } = req;

--- a/server/src/router/cardRoutes.mjs
+++ b/server/src/router/cardRoutes.mjs
@@ -1,10 +1,31 @@
 import express from "express";
 import cardControllers from "../controllers/cardControllers.mjs";
 
-const router = express.Router();
+import { PrismaClient } from "@prisma/client";
 
-router.get("/", async (req, res) => {
-	await cardControllers(req, res);
-});
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router
+	.get("/", async (req, res) => {
+		await cardControllers(req, res);
+	})
+	.delete("/", async (req, res) => {
+		const { query } = req;
+		const { id } = query;
+
+		await prisma.user
+			.delete({
+				where: {
+					id: parseInt(id),
+				},
+			})
+			.then(() => {
+				res
+					.status(200)
+					.json({ msg: "Your Card has been successfully deleted" });
+			})
+			.catch((err) => console.log("err", err));
+	});
 
 export default router;

--- a/server/src/router/cardRoutes.mjs
+++ b/server/src/router/cardRoutes.mjs
@@ -1,31 +1,16 @@
 import express from "express";
-import cardControllers from "../controllers/cardControllers.mjs";
 
-import { PrismaClient } from "@prisma/client";
+import getCard from "../controllers/cardControllers/getCard.mjs";
+import deleteCard from "../controllers/cardControllers/deleteCard.mjs";
 
 const router = express.Router();
-const prisma = new PrismaClient();
 
 router
 	.get("/", async (req, res) => {
-		await cardControllers(req, res);
+		await getCard(req, res);
 	})
 	.delete("/", async (req, res) => {
-		const { query } = req;
-		const { id } = query;
-
-		await prisma.user
-			.delete({
-				where: {
-					id: parseInt(id),
-				},
-			})
-			.then(() => {
-				res
-					.status(200)
-					.json({ msg: "Your Card has been successfully deleted" });
-			})
-			.catch((err) => console.log("err", err));
+		await deleteCard(req, res);
 	});
 
 export default router;


### PR DESCRIPTION
What I did:

- I can now delete cards based on the query that is send to endpoint
- It sends a 200 status code for a successful delete
- It sends a 400 status code for unsuccessful deletions
- At the same time of doing this I also refactored the get request for cards

Image showing the response from server on successful deletion:
![image](https://github.com/Personal-Projects-236/memory-app/assets/31186100/940a384a-0551-4e18-b86b-973f4307b1ca)
